### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP (Model Context Protocol) server for Azeth -- the trust, discovery, and payment layer for the machine economy. Provides 32 tools for AI agents to create accounts, make payments, discover services, manage reputation, and communicate via XMTP.
 
+<a href="https://glama.ai/mcp/servers/@azeth-protocol/mcp-azeth">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@azeth-protocol/mcp-azeth/badge" alt="mcp-azeth MCP server" />
+</a>
+
 ## Setup
 
 ### Claude Desktop


### PR DESCRIPTION
This PR adds a badge for the [mcp-azeth](https://glama.ai/mcp/servers/@azeth-protocol/mcp-azeth) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@azeth-protocol/mcp-azeth">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@azeth-protocol/mcp-azeth/badge" alt="mcp-azeth MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.